### PR TITLE
fix: uncomment PTX fallback for modern architectures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def make_gencode_flags(arch_list):
     for arch in arch_list.replace(";", " ").split():
         flags.extend([
             f"-gencode=arch=compute_{arch},code=sm_{arch}",
-            # f"-gencode=arch=compute_{arch},code=compute_{arch}",  # PTX fallback
+            f"-gencode=arch=compute_{arch},code=compute_{arch}",  # PTX fallback
         ])
     return flags
 


### PR DESCRIPTION
This PR uncomments the PTX fallback flag in make_gencode_flags. This enables forward compatibility and JIT compilation for newer GPUs (like Blackwell) that aren't explicitly listed in the default arch list, preventing "no kernel image" errors.

Resolves #8 